### PR TITLE
Do not fail on empty lines

### DIFF
--- a/src/ProjektTester.java
+++ b/src/ProjektTester.java
@@ -76,7 +76,7 @@ public class ProjektTester {
                     passed = false;
                     System.err.println("Test: " + arg + " fehlgeschlagen, weil Anzahl der Schauspieler nicht stimmen. Erwartet: " + schauspielerComma + ", erhalten: " + countComma(line));
                 }
-            } else {
+            } else if (line.startsWith("Filme")) {
                 if (!line.contains(filmeContains)) {
                     passed = false;
                     System.err.println("Test: " + arg + " fehlgeschlagen, weil Filme nicht stimmen.");


### PR DESCRIPTION
If the tested program prints an empty line, it's currently tested whether it contains the expected Movies. This causes the test to erroneously fail.